### PR TITLE
Fix broken no-response client request handler

### DIFF
--- a/src/FxMediator.Client/ClientMediator.cs
+++ b/src/FxMediator.Client/ClientMediator.cs
@@ -179,14 +179,8 @@ namespace FxMediator.Client
             //     }
             // }
         
-            EventHandlers[eventName] += new Func<string, string, Task>(async (requestId, payload) =>
+            EventHandlers[eventName] += new Func<string, Task>(async payload =>
             {
-                if (requestId != null)
-                {
-                    throw new FxMediatorException(
-                        $"EventHandler {eventName} expects a response but the payload type {payload.GetType().FullName} doesn't! This should never happen! See Fish!");
-                }
-
                 var obj = JsonConvert.DeserializeObject<TRequest>(payload);
                 await handler(obj);
             });

--- a/src/FxMediator.Client/ClientMediator.cs
+++ b/src/FxMediator.Client/ClientMediator.cs
@@ -18,7 +18,7 @@ namespace FxMediator.Client
             var eventName = MediatorUtils.GetEventNameForType<TRequest>();
             var payload = JsonConvert.SerializeObject(request);
 
-            TriggerServerEvent(eventName, null, payload);
+            TriggerServerEvent(eventName, payload);
         }
 
         

--- a/src/FxMediator.Server/ServerMediator.cs
+++ b/src/FxMediator.Server/ServerMediator.cs
@@ -118,14 +118,8 @@ namespace FxMediator.Server
             //     }
             // }
 
-            EventHandlers[eventName] += new Func<string, string, Task>(async (requestId, payload) =>
+            EventHandlers[eventName] += new Func<string, Task>(async (payload) =>
             {
-                if (requestId != null)
-                {
-                    throw new FxMediatorException(
-                        $"EventHandler {eventName} expects a response but the payload type {payload.GetType().FullName} doesn't! This should never happen! See Fish!");
-                }
-
                 var obj = JsonConvert.DeserializeObject<TRequest>(payload);
                 await handler(obj);
             });


### PR DESCRIPTION
Attempting to send a request to the client from the server when there is no response required, e.g.

```cs
 _mediator.SendToClient(player, new MoveToPositionRpcRequest
 {
     PedNetworkId = request.PedNetworkId,
     X = request.X,
     Y = request.Y,
     Z = request.Z
 });
```

Resulted in the following exception:

```cs
[   1292984] [    GTAProcess]             MainThrd/ Error invoking callback for event MoveToPositionRpcRequest: System.NullReferenceException: Object reference not set to an instance of an object.

[   1292984] [    GTAProcess]             MainThrd/   at FxMediator.Client.ClientMediator+<>c__DisplayClass11_0`1+<<AddRequestHandler>b__0>d[TRequest].MoveNext () [0x00020] in <018b4ac8299145f5a3cf0be9e6c2af1f>:0 
```

Discovered the event handler wanted to take in a `requestId` but this was not getting sent from the server. It isn't needed for a request that has no response, so this PR removes it from the event handler parameters.

The server equivalent (e.g. `_mediator.SendToServer(new ServerRequest())`) worked fine because it was passing up `null` in the `requestId` parameter. I've removed the `requestId` param from that event handler just for completeness.